### PR TITLE
Add Azure Blob storage connection type and export preview file action

### DIFF
--- a/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegAzureBlobConnectionHelper.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegAzureBlobConnectionHelper.xml
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>DEVIntegAzureBlobConnectionHelper</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+
+class DEVIntegAzureBlobConnectionHelper
+{
+    Common                      messageTypeTableRef;
+    BlobContainerClient         blobContainer;
+    DEVIntegTmpFiles            fileList;
+
+    str                         folderLocation;
+    str                         archiveLocation;
+    DEVIntegConnectionTypeId    connectionTypeId;
+    str                         messageTypeId;
+    str                         azureContainerReference;
+
+    System.Threading.CancellationToken  tokenNull;
+    System.Object                       objNull;
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>testConnection</Name>
+				<Source><![CDATA[
+    void testConnection()
+    {
+        boolean testisOK = true;
+        try
+        {
+            this.connect();
+
+            this.fillFiles();
+
+            this.printFileList();
+        }
+        catch( Exception::CLRError )
+        {
+            throw error(AifUtil::getClrErrorMessage());
+        }
+        catch
+        {
+            testisOK = false;
+        }
+        if (testisOK)
+        {
+            info("Test is OK");
+        }
+        else
+        {
+            throw error("Test Failed");
+        }
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>getConnectionString</Name>
+				<Source><![CDATA[
+    str   getConnectionString()
+    {
+        str connectionString;
+        DEVIntegConnectionType connectionType = DEVIntegConnectionType::find(connectionTypeId);
+        connectionString = connectionType.getConnectionString();
+
+        if (! connectionString)
+        {
+            throw error(strFmt("Connection string is not specified for message type %1", messageTypeId));
+        }
+
+        return connectionString;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>connect</Name>
+				<Source><![CDATA[
+    void connect()
+    {
+        if (! azureContainerReference)
+        {
+            throw error(strFmt("Container reference is not specified for message type %1", messageTypeId));
+        }
+        try
+        {
+            str                 connectionString  = this.getConnectionString();
+
+            blobContainer = new BlobContainerClient(connectionString, azureContainerReference);
+            boolean isExists;
+            isExists = blobContainer.Exists(tokenNull);
+            if (! isExists)
+            {
+                throw error(strFmt("Container '%1' doesn't exist (Type %2)", azureContainerReference, messageTypeId));
+            }
+        }
+        catch( Exception::CLRError )
+        {
+            throw error(AifUtil::getClrErrorMessage());
+        }
+
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>createFileInDirectory</Name>
+				<Source><![CDATA[
+    public void  createFileInDirectory(FileName  _fileName, DEVIntegFolderName  _archDir, System.IO.MemoryStream  _fileDataStream)
+    {
+        try
+        {
+            str blobName = strFmt("%1/%2", _archDir, _fileName);
+            BlobClient blobClient = blobContainer.GetBlobClient(blobName);
+
+            _fileDataStream.Position = 0;
+
+            blobClient.Upload(_fileDataStream, true, tokenNull);
+        }
+        catch( Exception::CLRError )
+        {
+            throw error(AifUtil::getClrErrorMessage());
+        }
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>moveFileToDirectory</Name>
+				<Source><![CDATA[
+    public void  moveFileToDirectory(DEVIntegTmpFiles  _fileRef, DEVIntegFolderName  _archDir, System.IO.MemoryStream  _fileDataStream, boolean _appendTimeStamp = true)
+    {
+        try
+        {
+            str sourceBlobName = strFmt("%1/%2", _fileRef.FolderName, _fileRef.FileName);
+            BlobClient sourceBlob = blobContainer.GetBlobClient(sourceBlobName);
+
+            FileName newFileName = _fileRef.FileName;
+            if (_appendTimeStamp)
+            {
+                container entityFileData = Docu::splitFilename(newFileName);
+
+                FileName            entityName = conPeek(entityFileData, 1);
+                DMFDefaultExtension extension = conPeek(entityFileData, 2);
+
+                System.DateTime dt = System.DateTime::Now;
+                str timeStamp = dt.ToString("yyyy'-'MM'-'dd'T'HHmmss");
+
+                entityName = entityName + '_' + timeStamp;
+                entityName = subStr(entityName, 1, 254);
+
+                newFileName = entityName + (extension ? strFmt(".%1", extension) : "");
+            }
+
+            str destBlobName = strFmt("%1/%2", _archDir, newFileName);
+            BlobClient destBlob = blobContainer.GetBlobClient(destBlobName);
+
+            // Blob storage has no server-side rename; archiving is a synchronous server-side copy followed by deleting the source.
+            destBlob.SyncCopyFromUri(sourceBlob.Uri, objNull, tokenNull);
+
+            sourceBlob.DeleteIfExists(DeleteSnapshotsOption::None, objNull, tokenNull);
+
+        }
+        catch( Exception::CLRError )
+        {
+            throw error(AifUtil::getClrErrorMessage());
+        }
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>readFile</Name>
+				<Source><![CDATA[
+    System.IO.MemoryStream  readFile(DEVIntegTmpFiles  _fileRef)
+    {
+        System.IO.MemoryStream memoryStream;
+
+        str blobName = strFmt("%1/%2", _fileRef.FolderName, _fileRef.FileName);
+        BlobClient blobClient = blobContainer.GetBlobClient(blobName);
+
+        // Ensure that the blob exists.
+        if (blobClient.Exists(tokenNull))
+        {
+            memoryStream = new System.IO.MemoryStream();
+            BlobDownloadInfo download = blobClient.Download(tokenNull);
+            System.IO.Stream  downloadContent = download.Content;
+
+            downloadContent.CopyTo(memoryStream);
+            memoryStream.Position = 0;
+        }
+        else
+        {
+            warning(strFmt("File '%1' doesn't exist", _fileRef.FileName));
+        }
+
+        return memoryStream;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>fillFiles</Name>
+				<Source><![CDATA[
+    DEVIntegTmpFiles fillFiles(DEVIntegFolderName  _folderName = folderLocation)
+    {
+        fileList = null;
+
+        // GetBlobsByHierarchy with a '/' delimiter mirrors the single-level file/folder split used by
+        // the file-share connector: BlobHierarchyItem.IsBlob is a file at this level, IsPrefix is a virtual subfolder.
+        str prefix = _folderName ? strFmt("%1/", _folderName) : "";
+
+        var azureItems  = blobContainer.GetBlobsByHierarchy(BlobTraits::None, BlobStates::None, "/", prefix, tokenNull);
+        var enum1  = azureItems.GetEnumerator();
+
+        while (enum1.MoveNext())
+        {
+            BlobHierarchyItem item = enum1.Current as BlobHierarchyItem;
+
+            if (item != null && item.IsBlob)
+            {
+                BlobItem blob = item.Blob;
+                FileName fileNameOnly = subStr(blob.Name, strLen(prefix) + 1, strLen(blob.Name) - strLen(prefix));
+
+                fileList.FileName    = fileNameOnly;
+                fileList.FolderName  = _folderName;
+                fileList.FileSize    = blob.Properties.ContentLength;
+                fileList.insert();
+            }
+        }
+        return fileList;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>printFileList</Name>
+				<Source><![CDATA[
+    void printFileList()
+    {
+        boolean     isAny;
+
+        fileList.clear();
+        while select fileList
+        {
+            info(strFmt("Name %1, Size %2", fileList.FileName, fileList.FileSize));
+            isAny = true;
+        }
+        if (! isAny)
+        {
+            info("No files found");
+        }
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>parmMessageTypeTableRef</Name>
+				<Source><![CDATA[
+    public Common parmMessageTypeTableRef(Common _messageTypeTableRef = messageTypeTableRef)
+    {
+        messageTypeTableRef = _messageTypeTableRef;
+        return messageTypeTableRef;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>initFromMessageTypeTable</Name>
+				<Source><![CDATA[
+    public void initFromMessageTypeTable(Common     _messageTable)
+    {
+
+        DEVIntegMessageTypeInbound          messageTypeInbound;
+        DEVIntegMessageTypeTableOutbound    messageTypeTableOutbound;
+
+        this.parmMessageTypeTableRef(_messageTable);
+
+        switch (_messageTable.TableId)
+        {
+            case tableNum(DEVIntegMessageTypeInbound):
+                messageTypeInbound = _messageTable;
+                folderLocation           = messageTypeInbound.ReadLocation;
+                archiveLocation          = messageTypeInbound.ArchiveLocation;
+                connectionTypeId         = messageTypeInbound.ConnectionTypeId;
+                messageTypeId            = messageTypeInbound.MessageTypeId;
+                azureContainerReference  = messageTypeInbound.AzureShareReference;
+                break;
+            case tableNum(DEVIntegMessageTypeTableOutbound):
+                messageTypeTableOutbound = _messageTable;
+                folderLocation           = messageTypeTableOutbound.OutputFolder;
+                archiveLocation          = '';
+                connectionTypeId         = messageTypeTableOutbound.ConnectionTypeId;
+                messageTypeId            = messageTypeTableOutbound.MessageTypeIdOutbound;
+                azureContainerReference  = messageTypeTableOutbound.AzureShareReference;
+                break;
+
+            default:
+                throw error(strFmt("Table %1 is not supported", _messageTable.TableId));
+        }
+
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>constructMessageTypeId</Name>
+				<Source><![CDATA[
+    static DEVIntegAzureBlobConnectionHelper constructMessageTypeId(DEVIntegMessageTypeIdInbound  _messageTypeId)
+    {
+        DEVIntegMessageTypeInbound             messageTypeTable;
+        DEVIntegAzureBlobConnectionHelper     res;
+        ;
+        messageTypeTable = DEVIntegMessageTypeInbound::find(_messageTypeId);
+        if (! messageTypeTable.RecId)
+        {
+            throw error(strFmt("Message type '%1' does not exist", _messageTypeId));
+        }
+
+        res = DEVIntegAzureBlobConnectionHelper::construct(messageTypeTable);
+        return res;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>construct</Name>
+				<Source><![CDATA[
+    static DEVIntegAzureBlobConnectionHelper construct(DEVIntegMessageTypeInbound     _messageTypeTable)
+    {
+        DEVIntegAzureBlobConnectionHelper        res = new DEVIntegAzureBlobConnectionHelper();
+        res.initFromMessageTypeTable(_messageTypeTable);
+        return res;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>constructOutbound</Name>
+				<Source><![CDATA[
+    static DEVIntegAzureBlobConnectionHelper constructOutbound(DEVIntegMessageTypeTableOutbound     _messageTypeTableOutbound)
+    {
+        DEVIntegAzureBlobConnectionHelper        res = new DEVIntegAzureBlobConnectionHelper();
+        res.initFromMessageTypeTable(_messageTypeTableOutbound);
+        return res;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>getAzureEnvHostedServiceName</Name>
+				<Source><![CDATA[
+    public static DEVIntegAzureEnvHostedServiceName getAzureEnvHostedServiceName()
+    {
+        var env = Microsoft.Dynamics.ApplicationPlatform.Environment.EnvironmentFactory::GetApplicationEnvironment();
+
+        return env.Infrastructure.HostedServiceName;
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegExportBulkBase.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegExportBulkBase.xml
@@ -371,6 +371,21 @@ public class DEVIntegExportBulkBase extends RunBaseBatch implements BatchRetryab
 ]]></Source>
 			</Method>
 			<Method>
+				<Name>writeFileAzureBlob</Name>
+				<Source><![CDATA[
+    public void  writeFileAzureBlob(FileName  _fileName, System.IO.MemoryStream  _fileDataStream)
+    {
+        if (! azureStorageConnectionHelper)
+        {
+            azureStorageConnectionHelper = this.getAzureStorageConnectionHelper();
+            azureStorageConnectionHelper.connect();
+        }
+        azureStorageConnectionHelper.createFileInDirectory(_fileName, messageTypeTableOutbound.OutputFolder, _fileDataStream);
+    }
+
+]]></Source>
+			</Method>
+			<Method>
 				<Name>writeFileSFTP</Name>
 				<Source><![CDATA[
     public void  writeFileSFTP(FileName  _fileName, System.IO.MemoryStream  _fileDataStream)
@@ -422,10 +437,10 @@ public class DEVIntegExportBulkBase extends RunBaseBatch implements BatchRetryab
         {
             throw error(strFmt("Can't find an Enabled message type for %1 type", messageTypeIdOutbound));
         }
-        if (messageTypeTableOutbound.connectionType().ConnectionTypeResource != DEVIntegConnectionTypeResource::AzureFileShare)
+        if (messageTypeTableOutbound.connectionType().ConnectionTypeResource != DEVIntegConnectionTypeResource::AzureFileShare && messageTypeTableOutbound.connectionType().ConnectionTypeResource != DEVIntegConnectionTypeResource::AzureBlob)
         {
-            throw error(strFmt("Message type %1 should have %2 connection(but %3 used)",
-                    messageTypeTableOutbound.MessageTypeIdOutbound, DEVIntegConnectionTypeResource::AzureFileShare, messageTypeTableOutbound.connectionType().ConnectionTypeResource));
+            throw error(strFmt("Message type %1 should have %2 or %3 connection(but %4 used)",
+                    messageTypeTableOutbound.MessageTypeIdOutbound, DEVIntegConnectionTypeResource::AzureFileShare, DEVIntegConnectionTypeResource::AzureBlob, messageTypeTableOutbound.connectionType().ConnectionTypeResource));
         }
         res = DEVIntegAzureStorageConnectionHelper::constructOutbound(messageTypeTableOutbound);
 
@@ -529,6 +544,10 @@ public class DEVIntegExportBulkBase extends RunBaseBatch implements BatchRetryab
             {
                 case DEVIntegConnectionTypeResource::AzureFileShare:
                     this.writeFileAzureStorage(fileName, memoryStream);
+                    info(strFmt("File %1 created in %2 folder", fileName, messageTypeTableOutbound.OutputFolder));
+                    break;
+                case DEVIntegConnectionTypeResource::AzureBlob:
+                    this.writeFileAzureBlob(fileName, memoryStream);
                     info(strFmt("File %1 created in %2 folder", fileName, messageTypeTableOutbound.OutputFolder));
                     break;
                 case DEVIntegConnectionTypeResource::SFTP:

--- a/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegExportDocumentsLog.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegExportDocumentsLog.xml
@@ -143,7 +143,7 @@ class DEVIntegExportDocumentsLog extends RunBaseBatch
 			<Method>
 				<Name>processExportDocumentLog</Name>
 				<Source><![CDATA[
-    public void processExportDocumentLog(DEVIntegExportDocumentLog _exportDocumentLog, DEVIntegMessageTypeTableOutbound  _messageTypeTableOutbound)
+    public void processExportDocumentLog(DEVIntegExportDocumentLog _exportDocumentLog, DEVIntegMessageTypeTableOutbound  _messageTypeTableOutbound, DEVIntegMessagesPreviewType _previewType = DEVIntegMessagesPreviewType::None)
     {
         DEVIntegExportDocumentLog    exportDocumentLogUpd;
         DEVIntegExportMessageBase    exportMessageBase;
@@ -167,6 +167,7 @@ class DEVIntegExportDocumentsLog extends RunBaseBatch
         {
             exportMessageBase = _messageTypeTableOutbound.getActionClass();
             exportMessageBase.parmProcessResults(processResults);
+            exportMessageBase.parmPreviewType(_previewType);
             
             infoCnt = infologLine();
             try
@@ -213,19 +214,24 @@ class DEVIntegExportDocumentsLog extends RunBaseBatch
     
                 refRecIf = _exportDocumentLog.recVersion;
                 exportDocumentLogUpd = DEVIntegExportDocumentLog::findRecId(_exportDocumentLog.RecId, true);
-                if (exportDocumentLogUpd.RecId && exportDocumentLogUpd.StatusChangeDate == _exportDocumentLog.StatusChangeDate)
-                {
-                    stopwatch.Stop();
 
-                    exportDocumentLogUpd.ExportStatus           = DEVIntegExportStatus::Sent;
-                    exportDocumentLogUpd.StatusChangeDate       = DateTimeUtil::utcNow();
-                    exportDocumentLogUpd.DurationInMilliseconds = any2Int(stopwatch.get_ElapsedMilliseconds());
-                    exportDocumentLogUpd.update();
-                }
-
-                if (_messageTypeTableOutbound.OutboundLogType == DEVIntegOutboundLogType::Full)
+                if (_previewType != DEVIntegMessagesPreviewType::PreviewOnly)
                 {
-                    DEVIntegMessageDataOutbound::insertLog(_exportDocumentLog, exception, processResults);
+                    if (exportDocumentLogUpd.RecId && exportDocumentLogUpd.StatusChangeDate == _exportDocumentLog.StatusChangeDate)
+                    {
+                        stopwatch.Stop();
+
+                        exportDocumentLogUpd.ExportStatus           = DEVIntegExportStatus::Sent;
+                        exportDocumentLogUpd.StatusChangeDate       = DateTimeUtil::utcNow();
+                        exportDocumentLogUpd.DurationInMilliseconds = any2Int(stopwatch.get_ElapsedMilliseconds());
+                        exportDocumentLogUpd.NumberOfRecords        = exportMessageBase.parmNumberOfRecords();
+                        exportDocumentLogUpd.update();
+                    }
+
+                    if (_messageTypeTableOutbound.OutboundLogType == DEVIntegOutboundLogType::Full)
+                    {
+                        DEVIntegMessageDataOutbound::insertLog(_exportDocumentLog, exception, processResults);
+                    }
                 }
     
                 ttsCommit;
@@ -474,7 +480,8 @@ class DEVIntegExportDocumentsLog extends RunBaseBatch
 			<Method>
 				<Name>exportSelectedRecords</Name>
 				<Source><![CDATA[
-    static void exportSelectedRecords(DEVIntegExportDocumentLog    _exportDocumentLog)
+    static void exportSelectedRecords(DEVIntegExportDocumentLog    _exportDocumentLog, 
+        DEVIntegMessagesPreviewType _previewType = DEVIntegMessagesPreviewType::None)
     {
         FormDataSource                exportDocumentLogDS;
         DEVIntegExportDocumentLog     exportDocumentLog;
@@ -487,7 +494,7 @@ class DEVIntegExportDocumentsLog extends RunBaseBatch
             exportDocumentLog.RecId;
             exportDocumentLog = exportDocumentLogDS.getNext())
         {
-            integExportDocumentLog.processExportDocumentLog(exportDocumentLog, exportDocumentLog.messageTypeTableOutbound());
+            integExportDocumentLog.processExportDocumentLog(exportDocumentLog, exportDocumentLog.messageTypeTableOutbound(), _previewType);
             processedCounter++;
         }
         DEV::dsResearch(_exportDocumentLog);

--- a/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegExportMessageBase.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegExportMessageBase.xml
@@ -11,9 +11,47 @@ class DEVIntegExportMessageBase
 
     DEVIntegMessageProcessResult     processResults;
 
+    int                              numberOfRecords;
+
+    // Controls preview behaviour for DEVIntegMessagesPreviewFile.
+    // If a child class modifies any data, you need to always add condition if (previewType != DEVIntegMesagesPreviewType::Preview)...
+    DEVIntegMessagesPreviewType       previewType;
+
 }
 ]]></Declaration>
 		<Methods>
+			<Method>
+				<Name>logIncNumberOfRecords</Name>
+				<Source><![CDATA[
+    public void logIncNumberOfRecords(int _increaseCount = 1)
+    {
+        numberOfRecords += _increaseCount;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>parmNumberOfRecords</Name>
+				<Source><![CDATA[
+    public int parmNumberOfRecords(int _numberOfRecords = numberOfRecords)
+    {
+        numberOfRecords = _numberOfRecords;
+        return numberOfRecords;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>parmPreviewType</Name>
+				<Source><![CDATA[
+    public DEVIntegMessagesPreviewType parmPreviewType(DEVIntegMessagesPreviewType _previewType = previewType)
+    {
+        previewType = _previewType;
+        return previewType;
+    }
+
+]]></Source>
+			</Method>
 			<Method>
 				<Name>parmProcessResults</Name>
 				<Source><![CDATA[
@@ -162,7 +200,15 @@ class DEVIntegExportMessageBase
                                           DEVIntegMessagesLoadAzureServiceBus     _loadAzureServiceBusCache,
                                            str  _messageData, str _messageLabel = '')
     {
-        _loadAzureServiceBusCache.sendMessage(_messageData, _messageLabel);
+        if (previewType == DEVIntegMessagesPreviewType::None)
+        {
+            _loadAzureServiceBusCache.sendMessage(_messageData, _messageLabel);
+        }
+        else
+        {
+            File::SendStringAsFileToUser(_messageData, _messageLabel ? strFmt('%1.txt', _messageLabel) : 'ExportLog.txt');
+        }
+
         if (messageTypeTableOutbound.OutboundLogType == DEVIntegOutboundLogType::Full && _exportDocumentLog.RecId)
         {
             processResults.parmMessageBodyStr(_messageData);
@@ -242,8 +288,15 @@ class DEVIntegExportMessageBase
                                str                          _request,
                                str                          _messageData)
     {
-        _loadFileStorageCache.sendMessage(_request, _messageData);
-        
+        if (previewType == DEVIntegMessagesPreviewType::None)
+        {
+            _loadFileStorageCache.sendMessage(_request, _messageData);
+        }
+        else
+        {
+            File::SendStringAsFileToUser(_messageData, 'ExportLog.txt');
+        }
+
         if (messageTypeTableOutbound.OutboundLogType == DEVIntegOutboundLogType::Full && _exportDocumentLog.RecId)
         {
             processResults.parmMessageBodyStr(_messageData);
@@ -257,13 +310,22 @@ class DEVIntegExportMessageBase
 				<Source><![CDATA[
     public void sendMessageFileStorageCache(DEVIntegExportDocumentLog        _exportDocumentLog,
                                             DEVIntegMessagesLoadBaseType     _loadFileStorageCache,
-                                            FileName  _fileName, System.IO.MemoryStream  _fileDataStream)
+                                            FileName  _fileName, 
+                                            System.IO.MemoryStream  _fileDataStream)
     {
-        _loadFileStorageCache.sendFile(_fileName,  _fileDataStream);
+        if (previewType == DEVIntegMessagesPreviewType::None)
+        {
+            _loadFileStorageCache.sendFile(_fileName,  _fileDataStream);
+        }
+        else
+        {
+            _fileDataStream.Position    = 0;
+            File::SendFileToUser(_fileDataStream, _fileName);
+        }
+
         if (messageTypeTableOutbound.OutboundLogType == DEVIntegOutboundLogType::Full && _exportDocumentLog.RecId)
         {
             processResults.parmMessageBodyStr(_fileName);
-
         }
     }
 

--- a/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegMessagesLoadAzureBlob.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegMessagesLoadAzureBlob.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>DEVIntegMessagesLoadAzureBlob</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+class DEVIntegMessagesLoadAzureBlob extends DEVIntegMessagesLoadBaseType
+{
+    DEVIntegAzureBlobConnectionHelper            azureBlobConnector;
+
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>loadMessageType</Name>
+				<Source><![CDATA[
+    public int loadMessageType()
+    {
+        int                 recordCount;
+        DEVIntegTmpFiles    fileList;
+
+        ;
+        if (! messageTypeTable.ArchiveLocation)
+        {
+            throw error(strFmt("Message type %1. Archive location is not specified", messageTypeTable.messageTypeId));
+        }
+
+        azureBlobConnector = DEVIntegAzureBlobConnectionHelper::construct(messageTypeTable);
+        azureBlobConnector.connect();
+
+        fileList = azureBlobConnector.fillFiles();
+
+        fileList.clear();
+        while select fileList
+            order by Filename
+        {
+            this.handleIncomingFile(messageTypeTable, fileList);
+            recordCount++;
+
+            if (this.checkMessageReadLimit())
+            {
+                break;
+            }
+        }
+
+        return recordCount;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>handleIncomingFile</Name>
+				<Source><![CDATA[
+    void handleIncomingFile(DEVIntegMessageTypeInbound   _messageTypeTable, DEVIntegTmpFiles     _fileRef)
+    {
+        System.IO.MemoryStream  memoryStream;
+
+        memoryStream = azureBlobConnector.readFile(_fileRef);
+        if (memoryStream != null)
+        {
+            ttsbegin;
+            DEVIntegMessageCreator messageCreator = DEVIntegMessageCreator::construct();
+            messageCreator.initFromStreamCopy(_fileRef, memoryStream).createMessage(_messageTypeTable);
+
+            azureBlobConnector.moveFileToDirectory(_fileRef, _messageTypeTable.ArchiveLocation, memoryStream,
+                _messageTypeTable.FileMoveNameChange == DEVIntegFileMoveNameChange::AppendDateTime ? true : false);
+            ttscommit;
+        }
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>testConnection</Name>
+				<Source><![CDATA[
+    void testConnection()
+    {
+        DEVIntegAzureBlobConnectionHelper     azureBlobConnectionHelper =  DEVIntegAzureBlobConnectionHelper::construct(messageTypeTable);
+        azureBlobConnectionHelper.testConnection();
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>testOutboundConnection</Name>
+				<Source><![CDATA[
+    void testOutboundConnection(DEVIntegMessageTypeTableOutbound  _messageTypeTableOutbound)
+    {
+        DEVIntegAzureBlobConnectionHelper     azureBlobConnectionHelper =  DEVIntegAzureBlobConnectionHelper::constructOutbound(_messageTypeTableOutbound);
+
+        azureBlobConnectionHelper.testConnection();
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>sendFile</Name>
+				<Source><![CDATA[
+    public void sendFile(FileName  _fileName, System.IO.MemoryStream  _fileDataStream)
+    {
+        ;
+        if (! azureBlobConnector)
+        {
+            azureBlobConnector = DEVIntegAzureBlobConnectionHelper::constructOutbound(messageTypeTableOutbound);
+            azureBlobConnector.connect();
+        }
+        azureBlobConnector.createFileInDirectory(_fileName, messageTypeTableOutbound.OutputFolder, _fileDataStream);
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegMessagesLoadBaseType.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegMessagesLoadBaseType.xml
@@ -182,6 +182,9 @@ class DEVIntegMessagesLoadBaseType
             case DEVIntegConnectionTypeResource::AzureFileShare:
                 shareClass = new DEVIntegMessagesLoadAzureFileShare();
                 break;
+            case DEVIntegConnectionTypeResource::AzureBlob:
+                shareClass = new DEVIntegMessagesLoadAzureBlob();
+                break;
             case DEVIntegConnectionTypeResource::AzureServiceBus:
                 shareClass = new DEVIntegMessagesLoadAzureServiceBus();
                 break;

--- a/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegMessagesPreviewFile.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxClass/DEVIntegMessagesPreviewFile.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>DEVIntegMessagesPreviewFile</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+public class DEVIntegMessagesPreviewFile extends RunBaseBatch implements BatchRetryable
+{
+    NoYesId      isUpdateMessageStatusToSent;
+    NoYesId      isSendToServiceBus;
+
+    DialogField  dlgIsUpdateMessageStatusToSent;
+
+    DEVIntegExportDocumentLog callerIntegExportDocumentLog;
+
+    #define.CurrentVersion(1)
+    #localmacro.CurrentList
+        isUpdateMessageStatusToSent
+    #endmacro
+
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>dialog</Name>
+				<Source><![CDATA[
+    public Object dialog()
+    {
+        DialogRunbase       dialog = super();
+        ;
+        dlgIsUpdateMessageStatusToSent  = dialog.addFieldValue(extendedtypestr(NoYesId), isUpdateMessageStatusToSent, "Update message status to Sent", "Mark it if you plan to send this file manually to the destination system");
+
+        return dialog;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>getFromDialog</Name>
+				<Source><![CDATA[
+    public boolean getFromDialog()
+    {
+        ;
+        isUpdateMessageStatusToSent = dlgIsUpdateMessageStatusToSent.value();
+
+        return super();
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>parmIsUpdateMessageStatusToSent</Name>
+				<Source><![CDATA[
+    public NoYesId parmIsUpdateMessageStatusToSent(NoYesId _isUpdateMessageStatusToSent = isUpdateMessageStatusToSent)
+    {
+        isUpdateMessageStatusToSent = _isUpdateMessageStatusToSent;
+        return isUpdateMessageStatusToSent;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>parmCallerIntegExportDocumentLog</Name>
+				<Source><![CDATA[
+    public DEVIntegExportDocumentLog parmCallerIntegExportDocumentLog(DEVIntegExportDocumentLog _callerIntegExportDocumentLog = callerIntegExportDocumentLog)
+    {
+        callerIntegExportDocumentLog = _callerIntegExportDocumentLog;
+        return callerIntegExportDocumentLog;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>pack</Name>
+				<Source><![CDATA[
+    public container pack()
+    {
+        return [#CurrentVersion, #CurrentList];
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>unpack</Name>
+				<Source><![CDATA[
+    public boolean unpack(container _packedClass)
+    {
+        Version    version = RunBase::getVersion(_packedClass);
+        switch (version)
+        {
+            case #CurrentVersion:
+                [version, #CurrentList] = _packedClass;
+                break;
+            default:
+                return false;
+        }
+        return true;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>validate</Name>
+				<Source><![CDATA[
+    public boolean validate(Object _calledFrom = null)
+    {
+        boolean ret = super(_calledFrom);
+
+        if (!callerIntegExportDocumentLog.RecId)
+        {
+            ret = checkFailed("Export document log record is required");
+        }
+
+        return ret;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>run</Name>
+				<Source><![CDATA[
+    public void run()
+    {
+        DEVIntegMessagesPreviewType          previewType;
+
+        previewType = isUpdateMessageStatusToSent ? DEVIntegMessagesPreviewType::PreviewWithUpdate
+                                                  : DEVIntegMessagesPreviewType::PreviewOnly;
+
+        DEVIntegExportDocumentsLog::exportSelectedRecords(this.parmCallerIntegExportDocumentLog(), previewType);
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>canRunInNewSession</Name>
+				<Source><![CDATA[
+    public boolean canRunInNewSession()
+    {
+        return false;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>canGoBatch</Name>
+				<Source><![CDATA[
+    public boolean canGoBatch()
+    {
+        return false;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>isRetryable</Name>
+				<Source><![CDATA[
+    public boolean isRetryable()
+    {
+        return true;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>construct</Name>
+				<Source><![CDATA[
+    public static DEVIntegMessagesPreviewFile construct()
+    {
+        return new DEVIntegMessagesPreviewFile();
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>description</Name>
+				<Source><![CDATA[
+    static ClassDescription description()
+    {
+        return "Get the file for the current export log record";
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>main</Name>
+				<Source><![CDATA[
+    public static void main(Args _args)
+    {
+        DEVIntegMessagesPreviewFile    runObject = DEVIntegMessagesPreviewFile::construct();
+        QueryBuildDataSource  qbds;
+        ;
+        if (_args.dataset() != tablenum(DEVIntegExportDocumentLog))
+        {
+            throw error(Error::missingRecord(funcname()));
+        }
+        runObject.parmCallerIntegExportDocumentLog(_args.record());
+        if (runObject.prompt())
+        {
+            runObject.runOperation();
+        }
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/DEVTutorial/DEVExternalIntegration/AxEnum/DEVIntegConnectionTypeResource.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxEnum/DEVIntegConnectionTypeResource.xml
@@ -29,5 +29,10 @@
 			<Label>Web</Label>
 			<Value>4</Value>
 		</AxEnumValue>
+		<AxEnumValue>
+			<Name>AzureBlob</Name>
+			<Label>Azure blob storage</Label>
+			<Value>5</Value>
+		</AxEnumValue>
 	</EnumValues>
 </AxEnum>

--- a/DEVTutorial/DEVExternalIntegration/AxEnum/DEVIntegMessagesPreviewType.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxEnum/DEVIntegMessagesPreviewType.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>DEVIntegMessagesPreviewType</Name>
+	<Help>Document log message export preview mode</Help>
+	<Label>Export preview mode</Label>
+	<UseEnumValue>No</UseEnumValue>
+	<EnumValues>
+		<AxEnumValue>
+			<Name>None</Name>
+			<Label>None</Label>
+		</AxEnumValue>
+		<AxEnumValue>
+			<Name>PreviewOnly</Name>
+			<Label>Preview only</Label>
+			<Value>1</Value>
+		</AxEnumValue>
+		<AxEnumValue>
+			<Name>PreviewWithUpdate</Name>
+			<Label>Preview with update</Label>
+			<Value>2</Value>
+		</AxEnumValue>
+	</EnumValues>
+</AxEnum>

--- a/DEVTutorial/DEVExternalIntegration/AxForm/DEVIntegConnectionType.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxForm/DEVIntegConnectionType.xml
@@ -28,7 +28,7 @@ public class DEVIntegConnectionType extends FormRun
         WebGroup.visible(DEVIntegConnectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::Web);
 
         ConnectionDetail.visible(DEVIntegConnectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureFileShare ||
-                                 DEVIntegConnectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureServiceBus);
+            DEVIntegConnectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureServiceBus || DEVIntegConnectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureBlob);
 
         DEVIntegConnectionType_ds.object(fieldNum(DEVIntegConnectionType,FTPPassword)).visible(
             DEVIntegConnectionType.ConnectionStringSource == DEVIntegConnectionStringSource::ManualEntry);

--- a/DEVTutorial/DEVExternalIntegration/AxForm/DEVIntegExportDocumentLog.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxForm/DEVIntegExportDocumentLog.xml
@@ -138,10 +138,10 @@ public class DEVIntegExportDocumentLog extends FormRun
 					<DataField>ConfirmedMessageID</DataField>
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
-					<DataField>createdBy</DataField>
+					<DataField>CreatedBy</DataField>
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
-					<DataField>createdDateTime</DataField>
+					<DataField>CreatedDateTime</DataField>
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
 					<DataField>DocumentId</DataField>
@@ -165,10 +165,13 @@ public class DEVIntegExportDocumentLog extends FormRun
 					<DataField>MessageTypeIdOutbound</DataField>
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
-					<DataField>modifiedBy</DataField>
+					<DataField>ModifiedBy</DataField>
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
-					<DataField>modifiedDateTime</DataField>
+					<DataField>ModifiedDateTime</DataField>
+				</AxFormDataSourceField>
+				<AxFormDataSourceField>
+					<DataField>NumberOfRecords</DataField>
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
 					<DataField>Partition</DataField>
@@ -303,7 +306,16 @@ public class DEVIntegExportDocumentLog extends FormRun
 								<Type>Button</Type>
 								<FormControlExtension
 									i:nil="true" />
-								<Text>View Document</Text>
+								<Text>Source Document</Text>
+							</AxFormControl>
+							<AxFormControl xmlns=""
+								i:type="AxFormMenuFunctionButtonControl">
+								<Name>DEVIntegMessagesPreviewFile</Name>
+								<Type>MenuFunctionButton</Type>
+								<FormControlExtension
+									i:nil="true" />
+								<MenuItemName>DEVIntegMessagesPreviewFile</MenuItemName>
+								<MenuItemType>Action</MenuItemType>
 							</AxFormControl>
 						</Controls>
 						<ArrangeMethod>Vertical</ArrangeMethod>
@@ -504,7 +516,6 @@ public class DEVIntegExportDocumentLog extends FormRun
 										<Type>String</Type>
 										<FormControlExtension
 											i:nil="true" />
-										<CacheDataMethod>Yes</CacheDataMethod>
 										<DataMethod>tableName</DataMethod>
 										<DataSource>DEVIntegExportDocumentLog</DataSource>
 									</AxFormControl>
@@ -525,6 +536,15 @@ public class DEVIntegExportDocumentLog extends FormRun
 										<FormControlExtension
 											i:nil="true" />
 										<DataField>DocumentId</DataField>
+										<DataSource>DEVIntegExportDocumentLog</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+										i:type="AxFormStringControl">
+										<Name>DetailsGroup_DocumentId2</Name>
+										<Type>String</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>DocumentId2</DataField>
 										<DataSource>DEVIntegExportDocumentLog</DataSource>
 									</AxFormControl>
 									<AxFormControl xmlns=""
@@ -564,6 +584,15 @@ public class DEVIntegExportDocumentLog extends FormRun
 										<FormControlExtension
 											i:nil="true" />
 										<DataField>StatusChangeDate</DataField>
+										<DataSource>DEVIntegExportDocumentLog</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+										i:type="AxFormIntegerControl">
+										<Name>DetailsTime_NumberOfRecords</Name>
+										<Type>Integer</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>NumberOfRecords</DataField>
 										<DataSource>DEVIntegExportDocumentLog</DataSource>
 									</AxFormControl>
 									<AxFormControl xmlns=""

--- a/DEVTutorial/DEVExternalIntegration/AxForm/DEVIntegMessageTypeInbound.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxForm/DEVIntegMessageTypeInbound.xml
@@ -37,7 +37,7 @@ public class DEVIntegMessageTypeInbound extends FormRun
         boolean                isFileBasedConnection = DEVIntegMessageTypeInbound.isFileBasedConnection();
 
         SourceGroupServiceBus.visible(connectionType.RecId && connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureServiceBus);
-        SourceGroupFileShare.visible(connectionType.RecId && connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureFileShare);
+        SourceGroupFileShare.visible(connectionType.RecId && (connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureFileShare || connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureBlob));
         SourceGroupSFTP.visible(connectionType.RecId && connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::SFTP);
 
         DEVIntegManualTextImport.visible(! isFileBasedConnection);
@@ -229,9 +229,6 @@ public class DEVIntegMessageTypeInbound extends FormRun
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
 					<DataField>CreatedDateTime</DataField>
-				</AxFormDataSourceField>
-				<AxFormDataSourceField>
-					<DataField>DefaultCompanyId</DataField>
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
 					<DataField>Description</DataField>

--- a/DEVTutorial/DEVExternalIntegration/AxForm/DEVIntegMessageTypeTableOutbound.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxForm/DEVIntegMessageTypeTableOutbound.xml
@@ -50,13 +50,24 @@ public class DEVIntegMessageTypeTableOutbound extends FormRun
 
         DEVIntegMessageTypeTableOutbound_ds.object(fieldNum(DEVIntegMessageTypeTableOutbound, OutputFolder)).visible(
             connectionType.RecId && (connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureFileShare ||
+            connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureBlob ||
                                       connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::SFTP));
         DEVIntegMessageTypeTableOutbound_ds.object(fieldNum(DEVIntegMessageTypeTableOutbound, AzureShareReference)).visible(
-            connectionType.RecId && connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureFileShare);
+            connectionType.RecId && (connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureFileShare || connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureBlob));
 
+        if (connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureFileShare)
+        {
+            DEVIntegMessageTypeTableOutbound_AzureShareReference.label("Share reference");
+        }
+        else if (connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureBlob)
+        {
+            DEVIntegMessageTypeTableOutbound_AzureShareReference.label("Blob container");
+        }
+        
         SQLParametersGroup.visible(DEVIntegMessageTypeTableOutbound.ClassName == classStr(DEVIntegExportBulkSQL));
         FileParametersGroup.visible(connectionType.RecId && 
             (connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureFileShare ||
+             connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureBlob ||
              connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::SFTP ||
              connectionType.ConnectionTypeResource == DEVIntegConnectionTypeResource::None));
         QueueParametersGroup.visible(connectionType.RecId &&
@@ -794,6 +805,7 @@ public class DEVIntegMessageTypeTableOutbound extends FormRun
 									<AxFormControl xmlns=""
 										i:type="AxFormStringControl">
 										<Name>DEVIntegMessageTypeTableOutbound_AzureShareReference</Name>
+										<AutoDeclaration>Yes</AutoDeclaration>
 										<Type>String</Type>
 										<FormControlExtension
 											i:nil="true" />

--- a/DEVTutorial/DEVExternalIntegration/AxMenuItemAction/DEVIntegMessagesPreviewFile.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxMenuItemAction/DEVIntegMessagesPreviewFile.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxMenuItemAction xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+	<Name>DEVIntegMessagesPreviewFile</Name>
+	<Label>Preview File</Label>
+	<Object>DEVIntegMessagesPreviewFile</Object>
+	<ObjectType>Class</ObjectType>
+	<SubscriberAccessLevel>
+		<Read xmlns="">Allow</Read>
+	</SubscriberAccessLevel>
+</AxMenuItemAction>

--- a/DEVTutorial/DEVExternalIntegration/AxTable/DEVIntegConnectionType.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxTable/DEVIntegConnectionType.xml
@@ -175,7 +175,8 @@ public class DEVIntegConnectionType extends common
     {
         boolean res;
         if (this.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureFileShare ||
-            this.ConnectionTypeResource == DEVIntegConnectionTypeResource::SFTP)
+            this.ConnectionTypeResource == DEVIntegConnectionTypeResource::SFTP ||
+            this.ConnectionTypeResource == DEVIntegConnectionTypeResource::AzureBlob)
         {
             res = true;
         }

--- a/DEVTutorial/DEVExternalIntegration/AxTable/DEVIntegExportDocumentLog.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxTable/DEVIntegExportDocumentLog.xml
@@ -401,6 +401,9 @@ public class DEVIntegExportDocumentLog extends common
 					<DataField>StatusChangeDate</DataField>
 				</AxTableFieldGroupField>
 				<AxTableFieldGroupField>
+					<DataField>NumberOfRecords</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
 					<DataField>DurationInMilliseconds</DataField>
 				</AxTableFieldGroupField>
 				<AxTableFieldGroupField>
@@ -528,6 +531,13 @@ public class DEVIntegExportDocumentLog extends common
 			<AllowEdit>No</AllowEdit>
 			<ExtendedDataType>Description</ExtendedDataType>
 			<Label>Document 2</Label>
+		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldInt">
+			<Name>NumberOfRecords</Name>
+			<ExtendedDataType>PositiveNumber</ExtendedDataType>
+			<HelpText>Number of exported records</HelpText>
+			<Label>Number of records</Label>
 		</AxTableField>
 	</Fields>
 	<FullTextIndexes />

--- a/DEVTutorial/DEVExternalIntegration/AxTable/DEVIntegMessageTypeInbound.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxTable/DEVIntegMessageTypeInbound.xml
@@ -65,7 +65,8 @@ public class DEVIntegMessageTypeInbound extends common
         boolean  res;
         DEVIntegConnectionTypeResource connectionTypeResource = this.connectionTypeResource();
         if (connectionTypeResource == DEVIntegConnectionTypeResource::AzureFileShare ||
-            connectionTypeResource == DEVIntegConnectionTypeResource::SFTP)
+            connectionTypeResource == DEVIntegConnectionTypeResource::SFTP ||
+            connectionTypeResource == DEVIntegConnectionTypeResource::AzureBlob)
         {
             res = true;   
         }

--- a/DEVTutorial/DEVExternalIntegration/AxTable/DEVIntegMessageTypeTableOutbound.xml
+++ b/DEVTutorial/DEVExternalIntegration/AxTable/DEVIntegMessageTypeTableOutbound.xml
@@ -187,7 +187,7 @@ public class DEVIntegMessageTypeTableOutbound extends common
 			<Method>
 				<Name>getFileName</Name>
 				<Source><![CDATA[
-    public Filename getFileName(TransDateTime  _exportDateTime)
+    public Filename getFileName(TransDateTime  _exportDateTime, DEVIntegExportDocumentLog _log = null)
     {
         Filename        res;
 
@@ -196,6 +196,17 @@ public class DEVIntegMessageTypeTableOutbound extends common
         if (this.FileName)
         {
             res = this.FileName;
+
+            if (strScan(this.FileName, '%documentId2', 1, strLen(this.FileName)))
+            {
+                res = strReplace(res, '%documentId2', _log.DocumentId2);
+            }
+
+            if (strScan(this.FileName, '%documentId', 1, strLen(this.FileName)))
+            {
+                res = strReplace(res, '%documentId', _log.DocumentId);
+            }            
+
             //if contains %d
             if (strScan(this.FileName, '%d', 1, strLen(this.FileName)))
             {


### PR DESCRIPTION
## Summary
- Adds `AzureBlob` as a new outbound/inbound connection type (alongside AzureFileShare/SFTP/ServiceBus/Web), backed by new `DEVIntegAzureBlobConnectionHelper` and `DEVIntegMessagesLoadAzureBlob` classes.
- Adds a "Preview File" action on the export document log that lets a user view the outbound message/file without sending it, optionally marking the log record as Sent (`DEVIntegMessagesPreviewType` threaded through `DEVIntegExportMessageBase`).
- Adds `NumberOfRecords` tracking on the export document log and `%documentId%`/`%documentId2%` filename placeholders.

## Test plan
- [ ] Build/sync the model and verify no compile errors
- [ ] Configure a connection with `ConnectionTypeResource = AzureBlob`, confirm the connection type, inbound, and outbound forms show the correct groups/labels
- [ ] Run an outbound export against an Azure Blob container and confirm the file lands in the expected container/folder
- [ ] Run an inbound import against an Azure Blob container and confirm files are picked up and archived
- [ ] Use the new "Preview File" action on an export document log record, with and without "Update message status to Sent"

🤖 Generated with [Claude Code](https://claude.com/claude-code)